### PR TITLE
fix: 为教师名称添加 fallback value

### DIFF
--- a/src/userscript/BJTU-Schedule-ics-csvGenerator/generator.user.js
+++ b/src/userscript/BJTU-Schedule-ics-csvGenerator/generator.user.js
@@ -219,7 +219,7 @@ function scheduleGetTable(isOrigin) {
           dateStr = dateStr.substring(dateStr.indexOf("第") + 1, dateStr.indexOf("周")) // 预处理
           courseTmp.initInfo = "第" + dateStr + "周"
           courseTmp.date = dateStr2Arr(dateStr)
-          courseTmp.teacher = courseListTmp[i][j].querySelectorAll("i")[k].innerText
+          courseTmp.teacher = courseListTmp[i][j].querySelectorAll("i")[k]?.innerText || ""
           courseTmp.allInfo =
             courseTmp.name +
             " " +


### PR DESCRIPTION
修复脚本在 研究生系统 中因为缺失 教师名称 而无法工作的bug